### PR TITLE
Cm copter 4.4 WS2811 tweaks

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -385,8 +385,8 @@ public:
 
     // See WS2812B spec for expected pulse widths
     static constexpr uint32_t NEOP_BIT_WIDTH_TICKS = 8;
-    static constexpr uint32_t NEOP_BIT_0_TICKS = 3;
-    static constexpr uint32_t NEOP_BIT_1_TICKS = 6;
+    static constexpr uint32_t NEOP_BIT_0_TICKS = 2; // bit pulse width for WS2811
+    static constexpr uint32_t NEOP_BIT_1_TICKS = 4; // bit pulse width for WS2811
     // neopixel does not use pulse widths at all
     static constexpr uint32_t PROFI_BIT_0_TICKS = 7;
     static constexpr uint32_t PROFI_BIT_1_TICKS = 14;

--- a/libraries/AP_SerialLED/AP_SerialLED.cpp
+++ b/libraries/AP_SerialLED/AP_SerialLED.cpp
@@ -56,7 +56,7 @@ bool AP_SerialLED::set_num_profiled(uint8_t chan, uint8_t num_leds)
 bool AP_SerialLED::set_RGB(uint8_t chan, int8_t led, uint8_t red, uint8_t green, uint8_t blue)
 {
     if (chan >= 1 && chan <= 16) {
-        return hal.rcout->set_serial_led_rgb_data(chan-1, led, red, green, blue);
+        return hal.rcout->set_serial_led_rgb_data(chan-1, led, green, red, blue);
     }
     return false;
 }


### PR DESCRIPTION
These are the timing and RGB component changes to modify NeoPixel to suit WS2811 LEDs.