### PR TITLE
CMCopter 4.6: Fixed sb_light_program_init_from_bytes missing header and linker issues when building on Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,3 +45,4 @@
 [submodule "modules/libskybrush"]
 	path = modules/libskybrush
 	url = https://github.com/skybrush-io/libskybrush
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -44,4 +44,4 @@
 	url = https://github.com/ArduPilot/lwip.git
 [submodule "modules/libskybrush"]
 	path = modules/libskybrush
-	url = https://github.com/alexshidagoatnocap/libskybrush
+	url = https://github.com/skybrush-io/libskybrush

--- a/.gitmodules
+++ b/.gitmodules
@@ -44,5 +44,4 @@
 	url = https://github.com/ArduPilot/lwip.git
 [submodule "modules/libskybrush"]
 	path = modules/libskybrush
-	url = https://github.com/skybrush-io/libskybrush
-	branch = main
+	url = https://github.com/alexshidagoatnocap/libskybrush

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -762,7 +762,7 @@ class sitl(Board):
         cfg.check_librt(env)
         cfg.check_feenableexcept()
 
-        env.LINKFLAGS += ['-pthread', '-Wl,--gc-sections,-ld_classic']
+        env.LINKFLAGS += ['-pthread', '-Wl', '--gc-sections', '-Wl']
 
         if cfg.env.DEBUG and 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
              env.LINKFLAGS += ['-fsanitize=address']

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -762,7 +762,7 @@ class sitl(Board):
         cfg.check_librt(env)
         cfg.check_feenableexcept()
 
-        env.LINKFLAGS += ['-pthread', '-Wl,--gc-sections']
+        env.LINKFLAGS += ['-pthread',]
 
         if cfg.env.DEBUG and 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
              env.LINKFLAGS += ['-fsanitize=address']

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -762,7 +762,7 @@ class sitl(Board):
         cfg.check_librt(env)
         cfg.check_feenableexcept()
 
-        env.LINKFLAGS += ['-pthread', '-Wl,--dead_strip,-ld_classic']
+        env.LINKFLAGS += ['-pthread', '-Wl,--gc-sections,-ld_classic']
 
         if cfg.env.DEBUG and 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
              env.LINKFLAGS += ['-fsanitize=address']

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -762,7 +762,7 @@ class sitl(Board):
         cfg.check_librt(env)
         cfg.check_feenableexcept()
 
-        env.LINKFLAGS += ['-pthread', '-Wl', '--gc-sections', '-Wl']
+        env.LINKFLAGS += ['-pthread', '-Wl,--gc-sections']
 
         if cfg.env.DEBUG and 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
              env.LINKFLAGS += ['-fsanitize=address']

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -762,7 +762,7 @@ class sitl(Board):
         cfg.check_librt(env)
         cfg.check_feenableexcept()
 
-        env.LINKFLAGS += ['-pthread', '-Wl,-dead_strip,-ld_classic']
+        env.LINKFLAGS += ['-pthread', '-Wl,--dead_strip,-ld_classic']
 
         if cfg.env.DEBUG and 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
              env.LINKFLAGS += ['-fsanitize=address']


### PR DESCRIPTION
The libskybrush submodule was tracking an older commit that had an issue with a header file that was fixed in the latest commit. I cloned the latest libskybrush repo and it worked from there. 

In Tools/ardupilotwaf/boards.py, the linker file added linker flags to the environment variables that will only work on macOS. This was fixed in the master branch of ardupilot but not on CMCopter-4.6, so I changed it to reflect the changes on the master branch.

 