### PR TITLE
fix: fix regression of gamma correction on LED colors

### DIFF
--- a/libraries/AC_DroneShowManager/DroneShowLED.h
+++ b/libraries/AC_DroneShowManager/DroneShowLED.h
@@ -155,10 +155,10 @@ public:
         if (max_brightness < _min_brightness_scaled) {
             red = green = blue = white = 0;
         } else {
-            red = _last_red;
-            green = _last_green;
-            blue = _last_blue;
-            white = _last_white;
+            red   = _gamma_lookup_table[_last_red];
+            green = _gamma_lookup_table[_last_green];
+            blue  = _gamma_lookup_table[_last_blue];
+            white = _gamma_lookup_table[_last_white];
         }
 
         if (set_raw_rgbw(red, green, blue, white)) {


### PR DESCRIPTION
This PR restores the gamma correction behavior that was unintentionally broken in commit 8b134dc9e5e912c128a9714bcca25c90804cd956.

The issue resulted in incorrect LED output due to gamma correction not being applied as intended.

This change implements the fix discussed and validated in the maintainer review.